### PR TITLE
[🐛 Bug] Overall Bug Fixing to: Shopping List, Notes & Insets

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,6 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="false"
-        android:windowSoftInputMode="adjustResize"
         android:theme="@style/Theme.Lumbridge">
 
         <!--

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
             android:name=".launcher.MainActivity"
             android:exported="true"
             android:theme="@style/Theme.Lumbridge"
+            android:windowSoftInputMode="adjustResize"
             android:configChanges="locale">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/eyther/lumbridge/features/editfinancialprofile/screens/EditFinancialProfileScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/editfinancialprofile/screens/EditFinancialProfileScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -90,6 +91,7 @@ fun EditFinancialProfileScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
         ) {
             when (state) {

--- a/app/src/main/java/com/eyther/lumbridge/features/editloan/screens/EditLoanScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/editloan/screens/EditLoanScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -122,6 +123,7 @@ fun EditLoanScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .then(
                     if (askForNotificationsPermission.value) Modifier.blur(5.dp) else Modifier

--- a/app/src/main/java/com/eyther/lumbridge/features/expenses/screens/ExpensesAddScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/expenses/screens/ExpensesAddScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -110,6 +111,7 @@ fun ExpensesAddScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
         ) {
             when (state) {
@@ -213,13 +215,12 @@ private fun ColumnScope.Content(
                 imeAction = ImeAction.Done
             )
         )
-
-        Spacer(modifier = Modifier.padding(top = DefaultPadding))
-
-        LumbridgeButton(
-            label = stringResource(id = R.string.save),
-            enableButton = state.shouldEnableSaveButton,
-            onClick = viewModel::onAddExpense
-        )
     }
+
+    LumbridgeButton(
+        modifier = Modifier.padding(DefaultPadding),
+        label = stringResource(id = R.string.save),
+        enableButton = state.shouldEnableSaveButton,
+        onClick = viewModel::onAddExpense
+    )
 }

--- a/app/src/main/java/com/eyther/lumbridge/features/expenses/screens/ExpensesEditScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/expenses/screens/ExpensesEditScreen.kt
@@ -9,8 +9,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -111,6 +114,8 @@ fun ExpensesEditScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
+                .verticalScroll(rememberScrollState())
                 .padding(vertical = DefaultPadding)
                 .then(
                     if (shouldShowDialog.value) Modifier.blur(5.dp) else Modifier
@@ -217,23 +222,23 @@ private fun ColumnScope.Content(
                 imeAction = ImeAction.Done
             )
         )
-
-        Spacer(modifier = Modifier.padding(top = DefaultPadding))
-
-        LumbridgeButton(
-            label = stringResource(id = R.string.save),
-            enableButton = state.shouldEnableSaveButton,
-            onClick = viewModel::save
-        )
-
-        Spacer(modifier = Modifier.padding(top = DefaultPadding))
-
-        LumbridgeButton(
-            label = stringResource(id = R.string.delete),
-            enableButton = true,
-            onClick = { shouldShowDialog.value = true }
-        )
     }
+
+    LumbridgeButton(
+        modifier = Modifier
+            .padding(horizontal = DefaultPadding)
+            .padding(top = DefaultPadding),
+        label = stringResource(id = R.string.save),
+        enableButton = state.shouldEnableSaveButton,
+        onClick = viewModel::save
+    )
+
+    LumbridgeButton(
+        modifier = Modifier.padding(DefaultPadding),
+        label = stringResource(id = R.string.delete),
+        enableButton = true,
+        onClick = { shouldShowDialog.value = true }
+    )
 
     if (shouldShowDialog.value) {
         AlertDialog(

--- a/app/src/main/java/com/eyther/lumbridge/features/expenses/screens/ExpensesOverviewScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/expenses/screens/ExpensesOverviewScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -195,6 +196,7 @@ fun ExpensesOverviewScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .padding(top = DefaultPadding)
                 .then(
                     if (selectedMonth.value != null) Modifier.blur(5.dp) else Modifier

--- a/app/src/main/java/com/eyther/lumbridge/features/feed/screens/FeedEditScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/feed/screens/FeedEditScreen.kt
@@ -43,11 +43,11 @@ import com.eyther.lumbridge.features.feed.model.edit.FeedEditScreenViewEffects
 import com.eyther.lumbridge.features.feed.model.edit.FeedEditScreenViewState
 import com.eyther.lumbridge.features.feed.viewmodel.edit.FeedEditScreenViewModel
 import com.eyther.lumbridge.features.feed.viewmodel.edit.IFeedEditScreenViewModel
-import com.eyther.lumbridge.ui.common.composables.components.text.TabbedDataOverview
 import com.eyther.lumbridge.model.news.RssFeedUi
 import com.eyther.lumbridge.ui.common.composables.components.card.ColumnCardWrapper
 import com.eyther.lumbridge.ui.common.composables.components.defaults.EmptyScreenWithButton
 import com.eyther.lumbridge.ui.common.composables.components.loading.LoadingIndicator
+import com.eyther.lumbridge.ui.common.composables.components.text.TabbedDataOverview
 import com.eyther.lumbridge.ui.common.composables.components.topAppBar.LumbridgeTopAppBar
 import com.eyther.lumbridge.ui.common.composables.components.topAppBar.TopAppBarVariation
 import com.eyther.lumbridge.ui.theme.DefaultPadding

--- a/app/src/main/java/com/eyther/lumbridge/features/feed/screens/FeedEditScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/feed/screens/FeedEditScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -106,6 +107,7 @@ fun FeedEditScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .padding(top = DefaultPadding)
         ) {
             when (state) {

--- a/app/src/main/java/com/eyther/lumbridge/features/feed/screens/FeedOverviewScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/feed/screens/FeedOverviewScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -120,7 +121,7 @@ fun FeedOverviewScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .consumeWindowInsets(paddingValues)
+                .imePadding()
         ) {
             Spacer(modifier = Modifier.height(DefaultPadding))
 

--- a/app/src/main/java/com/eyther/lumbridge/features/feed/screens/FeedOverviewScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/feed/screens/FeedOverviewScreen.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -117,6 +120,7 @@ fun FeedOverviewScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .consumeWindowInsets(paddingValues)
         ) {
             Spacer(modifier = Modifier.height(DefaultPadding))
 

--- a/app/src/main/java/com/eyther/lumbridge/features/overview/breakdown/screens/BreakdownScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/overview/breakdown/screens/BreakdownScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -71,6 +72,7 @@ fun BreakdownScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .then(
                     if (loanToDelete.longValue >= 0L) Modifier.blur(5.dp) else Modifier
                 )

--- a/app/src/main/java/com/eyther/lumbridge/features/overview/financialprofiledetails/screens/DetailsFinancialProfileScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/overview/financialprofiledetails/screens/DetailsFinancialProfileScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -73,6 +74,7 @@ fun DetailsFinancialProfileScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
         ) {
             when (viewState) {

--- a/app/src/main/java/com/eyther/lumbridge/features/overview/loandetails/screens/LoanDetailsScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/overview/loandetails/screens/LoanDetailsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -110,6 +111,7 @@ fun LoanDetailsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .then(
                     if (loanToDelete.value != null) Modifier.blur(5.dp) else Modifier

--- a/app/src/main/java/com/eyther/lumbridge/features/profile/editloans/screens/EditLoansListScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/profile/editloans/screens/EditLoansListScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -69,6 +70,7 @@ fun EditLoansListScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .then(
                     if (loanToDelete.longValue >= 0L) Modifier.blur(5.dp) else Modifier
                 )

--- a/app/src/main/java/com/eyther/lumbridge/features/profile/editprofile/screens/EditProfileScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/profile/editprofile/screens/EditProfileScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -95,6 +96,7 @@ fun EditProfileScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
         ) {
             when (state) {

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/currencyconverter/screens/CurrencyConverterScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/currencyconverter/screens/CurrencyConverterScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -74,6 +75,7 @@ fun CurrencyConverterScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
         ) {
             when (val state = viewModel.viewState.collectAsStateWithLifecycle().value) {
@@ -97,10 +99,6 @@ private fun Content(
         Input(
             state = state,
             viewModel = viewModel
-        )
-
-        Calculation(
-            state = state
         )
     }
 }
@@ -203,17 +201,18 @@ private fun ColumnScope.Input(
             )
         )
 
-        Spacer(modifier = Modifier.height(HalfPadding))
-
-        LumbridgeButton(
-            label = stringResource(id = R.string.tools_currency_converter_exchange_currency),
-            enableButton = state.shouldEnableCalculateButton,
-            isLoading = state.isCalculating,
-            onClick = viewModel::onConvert
+        Calculation(
+            state = state
         )
-
-        Spacer(modifier = Modifier.height(DefaultPadding))
     }
+
+    LumbridgeButton(
+        modifier = Modifier.padding(DefaultPadding),
+        label = stringResource(id = R.string.tools_currency_converter_exchange_currency),
+        enableButton = state.shouldEnableCalculateButton,
+        isLoading = state.isCalculating,
+        onClick = viewModel::onConvert
+    )
 }
 
 @Composable
@@ -221,51 +220,44 @@ private fun ColumnScope.Calculation(state: CurrencyConverterScreenViewState.Cont
     if (state.displayCalculation()) {
         Text(
             modifier = Modifier
-                .padding(
-                    start = DefaultPadding,
-                    end = DefaultPadding,
-                    top = DefaultPadding,
-                    bottom = HalfPadding
-                )
+                .padding(vertical = HalfPadding)
                 .align(Alignment.Start),
             text = stringResource(id = R.string.tools_currency_converter_result),
             style = MaterialTheme.typography.bodyLarge
         )
 
-        ColumnCardWrapper {
-            when {
-                state.hasError -> {
-                    Text(
-                        text = stringResource(id = R.string.tools_exchange_error),
-                        modifier = Modifier.padding(DefaultPadding),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
+        when {
+            state.hasError -> {
+                Text(
+                    text = stringResource(id = R.string.tools_exchange_error),
+                    modifier = Modifier.padding(vertical = HalfPadding),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
 
-                state.hasExchangeRate() -> {
-                    // Display the exchange rate and converted amount
-                    DataOverview(
-                        label = stringResource(id = R.string.tools_exchange_rate),
-                        text = stringResource(
-                            id = R.string.tools_exchange_rate_value,
-                            state.inputState.fromCurrency.getCurrencySymbol(),
-                            requireNotNull(state.exchangeRate).forceTwoDecimalsPlaces(),
-                            state.inputState.toCurrency.getCurrencySymbol()
-                        )
+            state.hasExchangeRate() -> {
+                // Display the exchange rate and converted amount
+                DataOverview(
+                    label = stringResource(id = R.string.tools_exchange_rate),
+                    text = stringResource(
+                        id = R.string.tools_exchange_rate_value,
+                        state.inputState.fromCurrency.getCurrencySymbol(),
+                        requireNotNull(state.exchangeRate).forceTwoDecimalsPlaces(),
+                        state.inputState.toCurrency.getCurrencySymbol()
                     )
+                )
 
-                    DataOverview(
-                        label = stringResource(id = R.string.tools_currency_converter_to),
-                        text = stringResource(
-                            id = R.string.tools_currency_converter_to_value,
-                            state.inputState.fromAmount.text?.toFloatOrNull()?.forceTwoDecimalsPlaces().orEmpty(),
-                            state.inputState.fromCurrency.getCurrencySymbol(),
-                            state.toExchangedAmount?.forceTwoDecimalsPlaces().orEmpty(),
-                            state.inputState.toCurrency.getCurrencySymbol()
-                        )
+                DataOverview(
+                    label = stringResource(id = R.string.tools_currency_converter_to),
+                    text = stringResource(
+                        id = R.string.tools_currency_converter_to_value,
+                        state.inputState.fromAmount.text?.toFloatOrNull()?.forceTwoDecimalsPlaces().orEmpty(),
+                        state.inputState.fromCurrency.getCurrencySymbol(),
+                        state.toExchangedAmount?.forceTwoDecimalsPlaces().orEmpty(),
+                        state.inputState.toCurrency.getCurrencySymbol()
                     )
-                }
+                )
             }
         }
     }

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/notes/screens/NoteDetailsScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/notes/screens/NoteDetailsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.AlertDialog
@@ -23,8 +24,11 @@ import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.res.stringResource
@@ -64,7 +68,11 @@ fun NoteDetailsScreen(
     val defaultTitle = stringResource(id = R.string.tools_notes_details)
 
     BackHandler {
-        viewModel.saveNotes(defaultTitle)
+        viewModel.saveNotes()
+    }
+
+    LaunchedEffect(defaultTitle) {
+        viewModel.setDefaultTitle(defaultTitle)
     }
 
     LaunchedEffect(Unit) {
@@ -84,7 +92,7 @@ fun NoteDetailsScreen(
             LumbridgeTopAppBar(
                 TopAppBarVariation.TitleAndIcon(
                     title = stringResource(id = label),
-                    onIconClick = { viewModel.saveNotes(defaultTitle) },
+                    onIconClick = { viewModel.saveNotes() },
                 ),
                 actions = {
                     Icon(
@@ -105,6 +113,7 @@ fun NoteDetailsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .then(
                     if (shouldShowDeleteNoteDialog.value) Modifier.blur(5.dp) else Modifier
                 )
@@ -141,7 +150,7 @@ private fun WriteNote(
 ) {
     Column(
         modifier = Modifier
-            .padding(top = DefaultPadding, start = DefaultPadding, end = DefaultPadding)
+            .padding(DefaultPadding)
     ) {
         BasicTextInput(
             modifier = Modifier

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/notes/screens/NoteDetailsScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/notes/screens/NoteDetailsScreen.kt
@@ -1,5 +1,6 @@
 package com.eyther.lumbridge.features.tools.notes.screens
 
+import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -62,6 +63,10 @@ fun NoteDetailsScreen(
     val state = viewModel.viewState.collectAsStateWithLifecycle().value
     val defaultTitle = stringResource(id = R.string.tools_notes_details)
 
+    BackHandler {
+        viewModel.saveNotes(defaultTitle)
+    }
+
     LaunchedEffect(Unit) {
         lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
             viewModel.viewEffects
@@ -74,16 +79,12 @@ fun NoteDetailsScreen(
         }
     }
 
-    LifecycleEventEffect(event = Lifecycle.Event.ON_PAUSE) {
-        viewModel.saveNotes(defaultTitle)
-    }
-
     Scaffold(
         topBar = {
             LumbridgeTopAppBar(
                 TopAppBarVariation.TitleAndIcon(
                     title = stringResource(id = label),
-                    onIconClick = { navController.popBackStack() },
+                    onIconClick = { viewModel.saveNotes(defaultTitle) },
                 ),
                 actions = {
                     Icon(
@@ -147,7 +148,7 @@ private fun WriteNote(
                 .fillMaxWidth(),
             state = state.inputState.title,
             defaultInitialValue = defaultTitle,
-            onInputChanged = { title -> onTitleChanged(title) },
+            onInputChanged = { cursorPos, title -> onTitleChanged(title) },
             textStyle = MaterialTheme.typography.titleSmall,
             singleLine = true
         )

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/notes/screens/NotesListScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/notes/screens/NotesListScreen.kt
@@ -39,10 +39,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.eyther.lumbridge.R
 import com.eyther.lumbridge.extensions.platform.navigateToWithArgs
+import com.eyther.lumbridge.features.tools.navigation.ToolsNavigationItem
 import com.eyther.lumbridge.features.tools.notes.model.list.NotesListScreenViewState
 import com.eyther.lumbridge.features.tools.notes.viewmodel.list.INotesListScreenViewModel
 import com.eyther.lumbridge.features.tools.notes.viewmodel.list.NotesListScreenViewModel
-import com.eyther.lumbridge.features.tools.navigation.ToolsNavigationItem
 import com.eyther.lumbridge.model.notes.NoteUi
 import com.eyther.lumbridge.ui.common.composables.components.buttons.LumbridgeButton
 import com.eyther.lumbridge.ui.common.composables.components.card.PeekContentCard

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/notes/screens/NotesListScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/notes/screens/NotesListScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
@@ -76,6 +77,7 @@ fun NotesListScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .then(
                     if (notesToDelete.longValue >= 0L) Modifier.blur(5.dp) else Modifier
                 )

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/notes/viewmodel/details/INoteDetailsScreenViewModel.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/notes/viewmodel/details/INoteDetailsScreenViewModel.kt
@@ -11,15 +11,21 @@ interface INoteDetailsScreenViewModel : INoteDetailsScreenInputHandler {
     val viewEffects: SharedFlow<NoteDetailsScreenViewEffect>
 
     /**
+     * Caches a default title for the note
+     * @param defaultTitle the default title to use if the user didn't provide one
+     */
+    fun setDefaultTitle(defaultTitle: String)
+
+    /**
      * Saves the notes list. If the user didn't provide a title, it uses the default title.
      *
      * This will be called on onPause and on onResume. If the user leaves the screen,
      * we save the list if there is any content to save. The user might've just opened the screen
      * and closed it without adding anything.
      *
-     * @param defaultTitle the default title to use if the user didn't provide one
+     * @param finish if true, the user is leaving the screen and we emit a finish effect
      */
-    fun saveNotes(defaultTitle: String)
+    fun saveNotes(finish: Boolean = true)
 
     /**
      * Attempts to delete the note. It uses the note ID stored in the view model to delete the note.

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/notes/viewmodel/details/NoteDetailsScreenViewModel.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/notes/viewmodel/details/NoteDetailsScreenViewModel.kt
@@ -86,18 +86,13 @@ class NoteDetailsScreenViewModel @Inject constructor(
 
     override fun saveNotes(defaultTitle: String) {
         val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-            Log.e(TAG, "Error saving note $noteId", throwable)
+            viewModelScope.launch {
+                Log.e(TAG, "Error saving note $noteId", throwable)
+                viewEffects.emit(NoteDetailsScreenViewEffect.NavigateBack)
+            }
         }
 
         viewModelScope.launch(coroutineExceptionHandler) {
-            if (inputState.value.text.text.isNullOrEmpty()) {
-                if (noteId != -1L) {
-                    deleteNoteUseCase(noteId)
-                }
-
-                return@launch
-            }
-
             val noteUi = NoteUi(
                 id = noteId,
                 title = inputState.value.title.text.orEmpty().ifEmpty { defaultTitle },
@@ -105,6 +100,7 @@ class NoteDetailsScreenViewModel @Inject constructor(
             )
 
             saveNoteUseCase(noteUi)
+            viewEffects.emit(NoteDetailsScreenViewEffect.NavigateBack)
         }
     }
 

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/notes/viewmodel/details/NoteDetailsScreenViewModel.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/notes/viewmodel/details/NoteDetailsScreenViewModel.kt
@@ -4,25 +4,28 @@ import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.eyther.lumbridge.features.tools.navigation.ToolsNavigationItem.Notes.Companion.ARG_NOTE_ID
 import com.eyther.lumbridge.features.tools.notes.model.details.NoteDetailsScreenViewEffect
 import com.eyther.lumbridge.features.tools.notes.model.details.NoteDetailsScreenViewState
 import com.eyther.lumbridge.features.tools.notes.viewmodel.details.delegate.INoteDetailsScreenInputHandler
 import com.eyther.lumbridge.features.tools.notes.viewmodel.details.delegate.NoteDetailsScreenInputHandler
-import com.eyther.lumbridge.features.tools.navigation.ToolsNavigationItem.Notes.Companion.ARG_NOTE_ID
 import com.eyther.lumbridge.model.notes.NoteUi
 import com.eyther.lumbridge.usecase.notes.DeleteNoteUseCase
 import com.eyther.lumbridge.usecase.notes.GetNoteUseCase
 import com.eyther.lumbridge.usecase.notes.SaveNoteUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class NoteDetailsScreenViewModel @Inject constructor(
     private val getNoteUseCase: GetNoteUseCase,
@@ -36,6 +39,7 @@ class NoteDetailsScreenViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "NoteDetailsScreenViewModel"
+        private const val NOTES_SAVE_DEBOUNCE_MS = 500L
     }
 
     override val viewState: MutableStateFlow<NoteDetailsScreenViewState> =
@@ -48,6 +52,8 @@ class NoteDetailsScreenViewModel @Inject constructor(
         "Note ID must be provided or defaulted to -1"
     }
 
+    private var cachedDefaultTitle: String? = null
+
     init {
         viewModelScope.launch {
             inputState
@@ -56,6 +62,14 @@ class NoteDetailsScreenViewModel @Inject constructor(
                         NoteDetailsScreenViewState.Content(newInputState)
                     }
                 }
+                .launchIn(this)
+
+            // Attempt to save the notes every time the input state changes,
+            // with a debounce of NOTES_SAVE_DEBOUNCE_MS to avoid saving too often
+            // while the user is still typing.
+            inputState
+                .debounce(NOTES_SAVE_DEBOUNCE_MS)
+                .onEach { saveNotes(finish = false) }
                 .launchIn(this)
 
             loadNoteDetails()
@@ -84,7 +98,11 @@ class NoteDetailsScreenViewModel @Inject constructor(
         }
     }
 
-    override fun saveNotes(defaultTitle: String) {
+    override fun setDefaultTitle(defaultTitle: String) {
+        cachedDefaultTitle = defaultTitle
+    }
+
+    override fun saveNotes(finish: Boolean) {
         val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
             viewModelScope.launch {
                 Log.e(TAG, "Error saving note $noteId", throwable)
@@ -95,12 +113,15 @@ class NoteDetailsScreenViewModel @Inject constructor(
         viewModelScope.launch(coroutineExceptionHandler) {
             val noteUi = NoteUi(
                 id = noteId,
-                title = inputState.value.title.text.orEmpty().ifEmpty { defaultTitle },
+                title = inputState.value.title.text.orEmpty().ifEmpty { cachedDefaultTitle.orEmpty() },
                 text = inputState.value.text.text.orEmpty()
             )
 
             saveNoteUseCase(noteUi)
-            viewEffects.emit(NoteDetailsScreenViewEffect.NavigateBack)
+
+            if (finish) {
+                viewEffects.emit(NoteDetailsScreenViewEffect.NavigateBack)
+            }
         }
     }
 

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/overview/screens/ToolsOverviewScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/overview/screens/ToolsOverviewScreen.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -44,6 +47,10 @@ fun ToolsOverviewScreen(
     toolsScreenViewModel: IToolsScreenViewModel = hiltViewModel<ToolsScreenViewModel>()
 ) {
     Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding()
+            .systemBarsPadding(),
         topBar = {
             LumbridgeTopAppBar(TopAppBarVariation.Title(title = stringResource(id = label)))
         }

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/recurringpayments/screens/EditRecurringPaymentsScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/recurringpayments/screens/EditRecurringPaymentsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -117,6 +118,7 @@ fun EditRecurringPaymentsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .then(
                     if (recurringPaymentToDelete.longValue >= 0L || askForNotificationsPermission.value) Modifier.blur(5.dp) else Modifier

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/recurringpayments/screens/RecurringPaymentsOverviewScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/recurringpayments/screens/RecurringPaymentsOverviewScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -104,6 +105,7 @@ fun RecurringPaymentsOverviewScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .then(
                     if (recurringPaymentToDelete.longValue >= 0L) Modifier.blur(5.dp) else Modifier
                 )

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/reminders/screens/RemindersEditScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/reminders/screens/RemindersEditScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -119,6 +120,7 @@ fun RemindersEditScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .then(
                     if (askForNotificationsPermission.value) Modifier.blur(5.dp) else Modifier

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/reminders/screens/RemindersOverviewScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/reminders/screens/RemindersOverviewScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -119,6 +120,7 @@ fun RemindersOverviewScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .then(
                     if (reminderToDelete.longValue >= 0L) Modifier.blur(5.dp) else Modifier
                 )

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/screens/ShoppingListDetailsScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/screens/ShoppingListDetailsScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -95,7 +97,11 @@ fun ShoppingListDetailsScreen(
     val defaultTitle = stringResource(id = R.string.tools_shopping_list)
 
     BackHandler {
-        viewModel.saveShoppingList(defaultTitle)
+        viewModel.saveShoppingList()
+    }
+
+    LaunchedEffect(defaultTitle) {
+        viewModel.setDefaultTitle(defaultTitle)
     }
 
     LaunchedEffect(Unit) {
@@ -115,7 +121,7 @@ fun ShoppingListDetailsScreen(
             LumbridgeTopAppBar(
                 TopAppBarVariation.TitleAndIcon(
                     title = stringResource(id = label),
-                    onIconClick = { viewModel.saveShoppingList(defaultTitle) },
+                    onIconClick = { viewModel.saveShoppingList() },
                 ),
                 actions = {
                     Icon(

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/screens/ShoppingListScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/screens/ShoppingListScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
@@ -76,6 +77,7 @@ fun ShoppingListsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .imePadding()
                 .then(
                     if (shoppingListToDelete.longValue >= 0L) Modifier.blur(5.dp) else Modifier
                 )

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/viewmodel/details/IShoppingListDetailsScreenViewModel.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/viewmodel/details/IShoppingListDetailsScreenViewModel.kt
@@ -11,15 +11,21 @@ interface IShoppingListDetailsScreenViewModel : IShoppingListDetailsScreenInputH
     val viewEffects: SharedFlow<ShoppingListDetailsScreenViewEffect>
 
     /**
+     * Caches a default title for the shopping list.
+     * @param defaultTitle the default title to use if the user didn't provide one
+     */
+    fun setDefaultTitle(defaultTitle: String)
+
+    /**
      * Saves the shopping list to the database. This will be called on onPause and on onResume. If the user leaves the screen,
      * we save the list.
      *
      * The idea here is to check if there is any content to save and only then insert it into the database. The user
      * might've just opened the screen and closed it without adding anything.
      *
-     * @param defaultTitle the default title to use if the user didn't provide one
+     * @param finish if true, the user is leaving the screen and we emit a finish effect
      */
-    fun saveShoppingList(defaultTitle: String)
+    fun saveShoppingList(finish: Boolean = true)
 
     /**
      * Attempts to delete the shopping list. It uses the shopping list ID stored

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/viewmodel/details/ShoppingListDetailsScreenViewModel.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/viewmodel/details/ShoppingListDetailsScreenViewModel.kt
@@ -98,18 +98,13 @@ class ShoppingListDetailsScreenViewModel @Inject constructor(
 
     override fun saveShoppingList(defaultTitle: String) {
         val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-            Log.e(TAG, "Error saving shopping list", throwable)
+            viewModelScope.launch {
+                viewEffects.emit(ShoppingListDetailsScreenViewEffect.NavigateBack)
+                Log.e(TAG, "Error saving shopping list", throwable)
+            }
         }
 
         viewModelScope.launch(coroutineExceptionHandler) {
-            if (inputState.value.items.isEmpty()) {
-                if (shoppingListId != -1L) {
-                    deleteShoppingListUseCase(shoppingListId)
-                }
-
-                return@launch
-            }
-
             val shoppingListUi = ShoppingListUi(
                 id = shoppingListId,
                 showTickedItems = inputState.value.showTickedItems,
@@ -124,6 +119,8 @@ class ShoppingListDetailsScreenViewModel @Inject constructor(
             )
 
             saveShoppingListUseCase(shoppingListUi)
+
+            viewEffects.emit(ShoppingListDetailsScreenViewEffect.NavigateBack)
         }
     }
 

--- a/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/viewmodel/details/delegate/IShoppingListDetailsScreenInputHandler.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/tools/shopping/viewmodel/details/delegate/IShoppingListDetailsScreenInputHandler.kt
@@ -16,7 +16,7 @@ interface IShoppingListDetailsScreenInputHandler {
     fun onEntrySelected(index: Int, selected: Boolean)
     fun onClearItem(index: Int)
     fun onKeyboardDelete(index: Int): Boolean
-    fun onKeyboardNext(index: Int)
+    fun onKeyboardNext(cursorPosition: Int?, index: Int)
 
     /**
      * Helper function to update the input state.

--- a/app/src/main/java/com/eyther/lumbridge/launcher/MainActivity.kt
+++ b/app/src/main/java/com/eyther/lumbridge/launcher/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.eyther.lumbridge.launcher
 
 import android.content.res.Configuration
+import android.graphics.Color
 import android.os.Bundle
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -13,7 +15,9 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -35,16 +39,18 @@ class MainActivity : AppCompatActivity() {
     private val viewModel: IMainActivityViewModel by viewModels<MainActivityViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge()
 
         notificationChannelBuilder.createNotificationChannel()
         checkAppSettings()
 
         setContent {
             val viewState = viewModel.viewState.collectAsStateWithLifecycle()
+            val darkTheme = viewState.value.uiMode.isDarkTheme()
 
-            LumbridgeTheme(darkTheme = viewState.value.uiMode.isDarkTheme()) {
+            LumbridgeTheme(darkTheme = darkTheme) {
                 MainScreen()
             }
         }

--- a/app/src/main/java/com/eyther/lumbridge/launcher/MainActivity.kt
+++ b/app/src/main/java/com/eyther/lumbridge/launcher/MainActivity.kt
@@ -3,12 +3,14 @@ package com.eyther.lumbridge.launcher
 import android.content.res.Configuration
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.ui.Modifier
@@ -33,8 +35,7 @@ class MainActivity : AppCompatActivity() {
     private val viewModel: IMainActivityViewModel by viewModels<MainActivityViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         notificationChannelBuilder.createNotificationChannel()
@@ -43,18 +44,8 @@ class MainActivity : AppCompatActivity() {
         setContent {
             val viewState = viewModel.viewState.collectAsStateWithLifecycle()
 
-            Box(
-                Modifier
-                    .padding(WindowInsets.systemBars.asPaddingValues())
-            ) {
-                Box(
-                    Modifier
-                        .consumeWindowInsets(WindowInsets.systemBars)
-                ) {
-                    LumbridgeTheme(darkTheme = viewState.value.uiMode.isDarkTheme()) {
-                        MainScreen()
-                    }
-                }
+            LumbridgeTheme(darkTheme = viewState.value.uiMode.isDarkTheme()) {
+                MainScreen()
             }
         }
     }

--- a/app/src/main/java/com/eyther/lumbridge/launcher/screens/MainScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/launcher/screens/MainScreen.kt
@@ -2,45 +2,49 @@
 
 package com.eyther.lumbridge.launcher.screens
 
-import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.exclude
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
 import com.eyther.lumbridge.ui.common.composables.components.bottomNavigation.LumbridgeBottomNavigationBar
 import com.eyther.lumbridge.ui.navigation.bottomNavigation.LumbridgeNavigationHost
-import com.eyther.lumbridge.ui.theme.LumbridgeTheme
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun MainScreen(modifier: Modifier = Modifier) {
+fun MainScreen() {
     val navController = rememberNavController()
 
     Scaffold(
-        modifier = modifier
-            .fillMaxSize(),
-        bottomBar = { LumbridgeBottomNavigationBar(navController) },
-        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets)
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding()
+            .systemBarsPadding(),
+        bottomBar = {
+            AnimatedVisibility(
+                visible = !WindowInsets.isImeVisible,
+                enter = slideInVertically(animationSpec = tween(100)) { it },
+                exit = fadeOut(snap())
+            ) {
+                LumbridgeBottomNavigationBar(navController)
+            }
+        }
     ) { paddingValues ->
         LumbridgeNavigationHost(
-            modifier = modifier
-                .padding(paddingValues)
-                .consumeWindowInsets(paddingValues),
+            modifier = Modifier.padding(paddingValues),
             navController = navController
         )
-    }
-}
-
-@Composable
-@Preview
-private fun MainScreenPreview() {
-    LumbridgeTheme {
-        MainScreen()
     }
 }

--- a/app/src/main/java/com/eyther/lumbridge/launcher/screens/MainScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/launcher/screens/MainScreen.kt
@@ -1,9 +1,15 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.eyther.lumbridge.launcher.screens
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -17,15 +23,17 @@ fun MainScreen(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
 
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize(),
         bottomBar = { LumbridgeBottomNavigationBar(navController) },
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.exclude(NavigationBarDefaults.windowInsets)
     ) { paddingValues ->
-        Box(
-            modifier = Modifier
+        LumbridgeNavigationHost(
+            modifier = modifier
                 .padding(paddingValues)
-        ) {
-            LumbridgeNavigationHost(modifier, navController)
-        }
+                .consumeWindowInsets(paddingValues),
+            navController = navController
+        )
     }
 }
 

--- a/app/src/main/java/com/eyther/lumbridge/mapper/recurringpayments/DomainToUi.kt
+++ b/app/src/main/java/com/eyther/lumbridge/mapper/recurringpayments/DomainToUi.kt
@@ -2,8 +2,8 @@ package com.eyther.lumbridge.mapper.recurringpayments
 
 import com.eyther.lumbridge.domain.model.recurringpayments.RecurringPaymentDomain
 import com.eyther.lumbridge.mapper.expenses.toUi
-import com.eyther.lumbridge.model.time.PeriodicityUi
 import com.eyther.lumbridge.model.recurringpayments.RecurringPaymentUi
+import com.eyther.lumbridge.model.time.PeriodicityUi
 import com.eyther.lumbridge.shared.time.model.Periodicity
 import java.time.DayOfWeek
 import java.time.LocalDate

--- a/app/src/main/java/com/eyther/lumbridge/mapper/recurringpayments/UiToDomain.kt
+++ b/app/src/main/java/com/eyther/lumbridge/mapper/recurringpayments/UiToDomain.kt
@@ -2,8 +2,8 @@ package com.eyther.lumbridge.mapper.recurringpayments
 
 import com.eyther.lumbridge.domain.model.recurringpayments.RecurringPaymentDomain
 import com.eyther.lumbridge.mapper.expenses.toDomain
-import com.eyther.lumbridge.model.time.PeriodicityUi
 import com.eyther.lumbridge.model.recurringpayments.RecurringPaymentUi
+import com.eyther.lumbridge.model.time.PeriodicityUi
 import com.eyther.lumbridge.shared.time.model.Periodicity
 
 fun RecurringPaymentUi.toDomain() = RecurringPaymentDomain(

--- a/app/src/main/java/com/eyther/lumbridge/ui/common/composables/components/input/TextInput.kt
+++ b/app/src/main/java/com/eyther/lumbridge/ui/common/composables/components/input/TextInput.kt
@@ -130,8 +130,8 @@ fun BasicTextInput(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     defaultInitialValue: String? = null,
-    onInputChanged: ((String) -> Unit) = {},
-    onFocusChanged: ((String) -> Unit) = {}
+    onInputChanged: ((Int, String) -> Unit) = {_, _ -> },
+    onFocusChanged: ((String) -> Unit) = {},
 ) {
     val initialText = state.text.takeIf { !it.isNullOrEmpty() } ?: defaultInitialValue.orEmpty()
 
@@ -164,7 +164,7 @@ fun BasicTextInput(
         onValueChange = {
             if (it.text.filter { char -> char.isLetterOrDigit() }.length > maxLength) return@BasicTextField
             text.value = it.copy(text = it.text)
-            onInputChanged(text.value.text)
+            onInputChanged(text.value.selection.start, text.value.text)
         },
         value = text.value,
         cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurface),

--- a/app/src/main/java/com/eyther/lumbridge/ui/common/composables/components/setting/Settings.kt
+++ b/app/src/main/java/com/eyther/lumbridge/ui/common/composables/components/setting/Settings.kt
@@ -4,7 +4,6 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.material3.Icon

--- a/app/src/main/java/com/eyther/lumbridge/ui/common/composables/components/topAppBar/TopAppBarVariation.kt
+++ b/app/src/main/java/com/eyther/lumbridge/ui/common/composables/components/topAppBar/TopAppBarVariation.kt
@@ -1,10 +1,8 @@
 package com.eyther.lumbridge.ui.common.composables.components.topAppBar
 
-import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.ui.graphics.vector.ImageVector
-import com.eyther.lumbridge.R
 
 /**
  * Represents the available variations for the toolbar.

--- a/app/src/main/java/com/eyther/lumbridge/ui/navigation/bottomNavigation/LumbridgeNavigationHost.kt
+++ b/app/src/main/java/com/eyther/lumbridge/ui/navigation/bottomNavigation/LumbridgeNavigationHost.kt
@@ -1,6 +1,5 @@
 package com.eyther.lumbridge.ui.navigation.bottomNavigation
 
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
@@ -18,7 +17,7 @@ fun LumbridgeNavigationHost(
     navController: NavHostController
 ) {
     NavHost(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier,
         navController = navController,
         startDestination = LumbridgeNavigationItem.Feed.route,
     ) {

--- a/app/src/main/java/com/eyther/lumbridge/ui/theme/Theme.kt
+++ b/app/src/main/java/com/eyther/lumbridge/ui/theme/Theme.kt
@@ -1,13 +1,19 @@
 package com.eyther.lumbridge.ui.theme
 
 import android.app.Activity
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -88,7 +94,7 @@ private val darkScheme = darkColorScheme(
 )
 
 @Composable
-fun LumbridgeTheme(
+fun ComponentActivity.LumbridgeTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
@@ -98,13 +104,13 @@ fun LumbridgeTheme(
         lightScheme
     }
 
+    val window = (LocalContext.current as Activity).window
     val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-        }
+
+    SideEffect {
+        window.statusBarColor = colorScheme.surface.toArgb()
+        window.navigationBarColor = colorScheme.surfaceContainer.toArgb()
+        WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
     }
 
     MaterialTheme(

--- a/app/src/main/java/com/eyther/lumbridge/usecase/loan/GetAllLoansUseCase.kt
+++ b/app/src/main/java/com/eyther/lumbridge/usecase/loan/GetAllLoansUseCase.kt
@@ -3,7 +3,6 @@ package com.eyther.lumbridge.usecase.loan
 import com.eyther.lumbridge.domain.model.locale.SupportedLocales
 import com.eyther.lumbridge.domain.repository.loan.LoanRepository
 import com.eyther.lumbridge.mapper.loan.toUi
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class GetAllLoansUseCase @Inject constructor(

--- a/app/src/main/java/com/eyther/lumbridge/usecase/user/profile/GetUserProfile.kt
+++ b/app/src/main/java/com/eyther/lumbridge/usecase/user/profile/GetUserProfile.kt
@@ -3,8 +3,6 @@ package com.eyther.lumbridge.usecase.user.profile
 import com.eyther.lumbridge.domain.repository.user.UserRepository
 import com.eyther.lumbridge.mapper.user.toUi
 import com.eyther.lumbridge.model.user.UserProfileUi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class GetUserProfile @Inject constructor(private val userRepository: UserRepository) {

--- a/shared/src/main/AndroidManifest.xml
+++ b/shared/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest>
 
 </manifest>


### PR DESCRIPTION
* Fix window insets for the keyboard, content no longer draws behind it
* Fix button uniformity, some buttons were inside the column card wrappers on non-empty states
* Fixed edgeToEdge and enabled it properly
* Fixed a bug where leaving the app and coming back again, while writing a note or a shopping list, would save multiple copies of a note or shopping list
* Improved shopping list and notes saving features - now auto-saves every 500ms of inactive time, apart from saving on close
* Improved shopping list keyboard features, pressing RETURN mid word now carries the second half to the next line
* Attempted to improve focus and scrolls on the shopping list, trying to maintain focus on the proper item at all times (needs further improvements)