### PR TITLE
[🚀  Feature] Text color on allocations & fix overview calculation

### DIFF
--- a/app/src/main/java/com/eyther/lumbridge/features/expenses/screens/ExpensesOverviewScreen.kt
+++ b/app/src/main/java/com/eyther/lumbridge/features/expenses/screens/ExpensesOverviewScreen.kt
@@ -900,6 +900,7 @@ private fun AllocationItem(
                 .height(8.dp)
                 .align(Alignment.CenterVertically)
                 .width(progressWidth),
+            progressColor = if (percentage > 1.0f) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
             progress = percentage
         )
 

--- a/app/src/main/java/com/eyther/lumbridge/model/expenses/ExpensesMonthUi.kt
+++ b/app/src/main/java/com/eyther/lumbridge/model/expenses/ExpensesMonthUi.kt
@@ -17,11 +17,7 @@ data class ExpensesMonthUi(
     val remainder: Float = -1f,
     val expanded: Boolean = false
 ) {
-
     fun getDateWithLocale(): String {
         return (year to month).toLocalDate().toMonthYearDateString().capitalise()
     }
-
-    val totalGained: Float
-        get() = snapshotMonthlyNetSalary + gained
 }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -6,8 +6,8 @@ object Config {
     const val MIN_SDK = 29
     const val TARGET_SDK = 34
 
-    const val VERSION = 42
-    const val VERSION_NAME = "2.1.0"
+    const val VERSION = 43
+    const val VERSION_NAME = "2.1.1"
 
     const val JAVA_VERSION = "17"
     val JAVA_TARGET = JavaVersion.VERSION_17


### PR DESCRIPTION
* Added red text colour whenever the spent for the allocation that month is exceeded
* Fixed an issue with the calculations, where the fold accumulator was accumulating duplicated gains.


| red text bar | alternative |
| ----------- | -- | 
| ![image](https://github.com/user-attachments/assets/7b2ad5c1-d43b-469d-93ab-de23e190316a) | ![image](https://github.com/user-attachments/assets/4aa0011e-cb6f-4260-ad56-1036c8d50d02)  | 