### PR TITLE
Fix missing types and local variables overriding in PreferencesRepository

### DIFF
--- a/data/src/main/java/com/eyther/lumbridge/data/repository/preferences/PreferencesRepositoryImpl.kt
+++ b/data/src/main/java/com/eyther/lumbridge/data/repository/preferences/PreferencesRepositoryImpl.kt
@@ -39,9 +39,9 @@ class PreferencesRepositoryImpl @Inject constructor(
         showAllocationsOnExpenses: Boolean,
         addFoodCardToNecessitiesAllocation: Boolean
     ) = withContext(schedulers.io) {
-        override val currentPreferences = getPreferences()
+        val currentPreferences = getPreferences()
 
-        override val newPreferences = currentPreferences?.copy(
+        val newPreferences = currentPreferences?.copy(
             isDarkMode = isDarkMode,
             appLanguage = appLanguage,
             showAllocationsOnExpenses = showAllocationsOnExpenses,

--- a/domain/src/main/java/com/eyther/lumbridge/domain/repository/preferences/PreferencesRepository.kt
+++ b/domain/src/main/java/com/eyther/lumbridge/domain/repository/preferences/PreferencesRepository.kt
@@ -12,8 +12,6 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 interface PreferencesRepository {
-    val currentPreferences
-    val newPreferences
     suspend fun getPreferences(): Preferences?
     fun getPreferencesFlow(): Flow<Preferences?>
     suspend fun updatePreferences( isDarkMode: Boolean, appLanguage: SupportedLanguages, showAllocationsOnExpenses: Boolean, addFoodCardToNecessitiesAllocation: Boolean )


### PR DESCRIPTION
This PR fixes an issue where local variables `currentPreferences` and `newPreferences` were incorrectly added to the `PreferencesRepository` interface without types, preventing compilation. We've removed them from the interface and removed the `override` modifier from the local variables in `PreferencesRepositoryImpl`.

---
*PR created automatically by Jules for task [8187031187967224544](https://jules.google.com/task/8187031187967224544) started by @ruialmeida51*